### PR TITLE
bugfix based on elpaso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Staged
 
+## v0.2.2 
+- Bug fix in level computation of nodes 
+- New exceptions: `ICException`, `NetworkException`, `ControlException`
+
 ## v0.2.1
 - Updates compat for LoggingExtras
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GasTranSim"
 uuid = "69f9d653-1b8b-4f14-83cd-52913e0d1f1c"
 authors = ["Shriram Srinivasan and Kaarthik Sundar"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"

--- a/src/core/ic.jl
+++ b/src/core/ic.jl
@@ -52,8 +52,8 @@ function build_ic(data::Dict{String,Any})::Dict{Symbol,Any}
     end 
 
     # compressor flow initial condition is not mandatory
-    (isempty(ic[:node])) && (@error "nodal pressure initial condition missing") 
-    (isempty(ic[:pipe]["mass_flow"])) && (@error "pipe flow initial condition missing")
+    (isempty(ic[:node])) && (throw(ICException("nodal pressure"))) 
+    (isempty(ic[:pipe]["mass_flow"])) && (throw(ICException("pipe flow")))
     
     return ic
 end 

--- a/src/core/initialize_ts.jl
+++ b/src/core/initialize_ts.jl
@@ -85,18 +85,19 @@ function _evaluate_level_of_node!(ts::TransientSimulator, node_id::Int64)
     end
     for ci in ref(ts, :incoming_compressors, node_id)
         node_across_ci = ref(ts, :compressor, ci, "fr_node")
-        if length(ref(ts, :incoming_compressors, node_across_ci)) + length(ref(ts, :outgoing_compressors, node_across_ci))  > 1
-            ref(ts, :node, node_id)["level"] = 2
-            return
+        if length(ref(ts, :incoming_compressors, node_across_ci)) + length(ref(ts, :outgoing_compressors, node_across_ci))  >  1
+            @error "Network topology violates hypothesis; 3 compressors are in series"
+            exit()
         end
     end
     for ci in ref(ts, :outgoing_compressors, node_id)
         node_across_ci = ref(ts, :compressor, ci, "to_node")
         if length(ref(ts, :incoming_compressors, node_across_ci)) + length(ref(ts, :outgoing_compressors, node_across_ci))  > 1
-            ref(ts, :node, node_id)["level"] = 2
-            return
+            @error "Network topology violates hypothesis; 3 compressors are in series"
+            exit()
         end
     end
+    ref(ts, :node, node_id)["level"] = 2
     return
 end
 
@@ -146,7 +147,7 @@ function add_node_ordering_for_compressor_flow_computation!(ts::TransientSimulat
     if length(compressors_accounted_for) < num_compressors
         @info "The flows in some compressors cannot be calculated"
         for id in compressor_ids 
-            !(id in c) && (push!(compressor_ids_with_uncomputable_flow, id))
+            !(id in compressors_accounted_for) && (push!(compressor_ids_with_uncomputable_flow, id))
         end 
     end 
 

--- a/src/core/initialize_ts.jl
+++ b/src/core/initialize_ts.jl
@@ -51,7 +51,6 @@ function add_pipe_grid_to_ref!(ts::TransientSimulator)
         n = 1
         if num_segments < 1
             throw(CFLException(string(key)))
-            # @error "Time step too large for CFL condition. Spatial discretization failed"
         else
             n = floor(Int64, num_segments) + 1
         end
@@ -86,15 +85,13 @@ function _evaluate_level_of_node!(ts::TransientSimulator, node_id::Int64)
     for ci in ref(ts, :incoming_compressors, node_id)
         node_across_ci = ref(ts, :compressor, ci, "fr_node")
         if length(ref(ts, :incoming_compressors, node_across_ci)) + length(ref(ts, :outgoing_compressors, node_across_ci))  >  1
-            @error "Network topology violates hypothesis; 3 compressors are in series"
-            exit()
+            throw(NetworkException("3 compressors are in series"))
         end
     end
     for ci in ref(ts, :outgoing_compressors, node_id)
         node_across_ci = ref(ts, :compressor, ci, "to_node")
         if length(ref(ts, :incoming_compressors, node_across_ci)) + length(ref(ts, :outgoing_compressors, node_across_ci))  > 1
-            @error "Network topology violates hypothesis; 3 compressors are in series"
-            exit()
+            throw(NetworkException("3 compressors are in series"))
         end
     end
     ref(ts, :node, node_id)["level"] = 2

--- a/src/core/run_ts.jl
+++ b/src/core/run_ts.jl
@@ -46,7 +46,7 @@ function advance_node_pressure_mass_flux!(ts::TransientSimulator, run_type::Symb
         elseif ctrl_type == flow_control
             _solve_for_pressure_at_node_and_neighbours!(key, val, ts)
         else
-            @error "control type unknown at advance_pressure_mass_flux_node!"
+            (throw(ControlException("control type unknown at advance_pressure_mass_flux_node")))
         end
     end
 

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -12,10 +12,28 @@ struct TransientSimulator
 end
 
 mutable struct CFLException <: Exception
-    var::String
+    var::AbstractString
 end
 
+mutable struct NetworkException <: Exception 
+    var::AbstractString 
+end 
+
+mutable struct ICException <: Exception 
+    var::AbstractString 
+end 
+
+mutable struct ControlException <: Exception 
+    var::AbstractString 
+end 
+
 Base.showerror(io::IO, e::CFLException) = print(io, "CFL condition fails, time-step too large for component ", e.var, "!")
+
+Base.showerror(io::IO, e::NetworkException) = print(io, "Network topology incompatible with simulator; ", e.var, "!")
+
+Base.showerror(io::IO, e::ICException) = print(io, "Initial condition missing: ", e.var, "!")
+
+Base.showerror(io::IO, e::ControlException) = print(io, "Control values: ", e.var, "!")
 
 ref(ts::TransientSimulator) = ts.ref
 ref(ts::TransientSimulator, key::Symbol) = ts.ref[key]
@@ -47,7 +65,7 @@ function control(ts::TransientSimulator,
     key::Symbol, id::Int64, t::Real)::Tuple{CONTROL_TYPE,Float64}
     (key == :node) && (return get_nodal_control(ts, id, t))
     (key == :compressor) && (return get_compressor_control(ts, id, t))
-    @error "control available only for nodes and compressors"
+    throw(ControlException("control available only for nodes and compressors"))
     return CONTROL_TYPE::unknown_control, 0.0
 end
 


### PR DESCRIPTION
- Bug fix in computation of levels of node. 
- Added new exceptions for missing IC data, control values, and network topology restrictions.
- replaced `@error` with `throw(ex)` at all places.